### PR TITLE
Allow ^4.5.0 and ^5.0.0 of stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "stylelint": "^4.5.0"
   },
   "peerDependencies": {
-    "stylelint": "^4.5.0"
+    "stylelint": "^4.5.0 || ^5.0.0"
   },
   "scripts": {
     "ava": "ava --verbose \"__tests__/**/*.js\"",


### PR DESCRIPTION
As the caret shortcut can't accomodate multiple caret ranges, specify the total range manually.