### PR TITLE
Update AVA v0.14.0

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -75,7 +75,7 @@ test("no warnings with valid css", t => {
   .then(data => {
     const { errored, results } = data
     const { warnings } = results[0]
-    t.notOk(errored, "no errored")
+    t.falsy(errored, "no errored")
     t.is(warnings.length, 0, "flags no warnings")
   })
 })
@@ -88,7 +88,7 @@ test("a warning with invalid css", t => {
   .then(data => {
     const { errored, results } = data
     const { warnings } = results[0]
-    t.ok(errored, "errored")
+    t.truthy(errored, "errored")
     t.is(warnings.length, 1, "flags one warning")
     t.is(warnings[0].text, "Expected a leading zero (number-leading-zero)", "correct warning text")
   })

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "index.js"
   ],
   "devDependencies": {
-    "ava": "^0.13.0",
+    "ava": "^0.14.0",
     "eslint": "^2.4.0",
     "eslint-config-stylelint": "^1.0.0",
     "npmpub": "^3.0.3",


### PR DESCRIPTION
https://github.com/sindresorhus/ava/releases/tag/v0.14.0
> The biggest change in this release is the deprecation of `t.ok`, `t.notOk`, and `t.same` assertions. We have published a [codemod](https://github.com/jamestalmage/ava-codemods) which should make switching to the new API very easy.

Pull request includes above updated assertion methods renaming via [ava-codemods](https://github.com/jamestalmage/ava-codemods)
