### PR TITLE
Remove NodeJS 0.12.x from CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
 node_js:
   - '5'
   - '4'
-  - '0.12'
 
 before_install:
   # remove outdated deps, assists with cache maintenance

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - nodejs_version: 5
     - nodejs_version: 4
-    - nodejs_version: 0.12
 
 version: "{build}"
 build: off


### PR DESCRIPTION
In a not too distant future WordPress will default to NodeJS > v4.2.1 LTS