### PR TITLE
fix: Deprecated `no-missing-eof-newline` rule. Use the new `no-missing-end-of-source-newline` rule instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added: `selector-attribute-quotes` rule.
 * Added: `font-weight-notation` rule.
 * Added: `max-line-length` rule.
+* Deprecated `no-missing-eof-newline` rule. Use the new `no-missing-end-of-source-newline` rule instead.
 
 # 8.0.0
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = {
     "no-eol-whitespace": true,
     "no-extra-semicolons": true,
     "no-invalid-double-slash-comments": true,
-    "no-missing-eof-newline": true,
+    "no-missing-end-of-source-newline": true,
     "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
     "property-case": "lower",


### PR DESCRIPTION
Fixes #81