### PR TITLE
chore: bump minimum NodeJS requirement to 6.9.1 and drop NodeJS 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
 node_js:
   - '7'
   - '6'
-  - '4'
 
 before_install:
   # remove outdated deps, assists with cache maintenance

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     - nodejs_version: 7
     - nodejs_version: 6
-    - nodejs_version: 4
 
 version: "{build}"
 build: off

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "scss.js"
   ],
   "engines": {
-    "node": ">=4.2.1"
+    "node": ">=6.9.1"
   },
   "devDependencies": {
     "ava": "^0.17.0",


### PR DESCRIPTION
Fixes #117