### PR TITLE
chore(package): update eslint to version 3.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "node": ">=6.9.1"
   },
   "devDependencies": {
-    "eslint": "^3.0.0",
+    "eslint": "^3.19.0",
     "eslint-config-stylelint": "^6.0.0",
     "eslint-plugin-ava": "^4.0.0",
     "jest": "^19.0.2",


### PR DESCRIPTION
Technically this isn't required but it has the advantage in that Greenkeeper bot will remove the ~14 branches that are currently sitting here in the repo working as Greenkeeper placeholders 🤷‍♂️ 