### PR TITLE
fix: Ignore `relative` keyword names in `font-weight-notation` rule.

### DIFF
--- a/__tests__/values-valid.css
+++ b/__tests__/values-valid.css
@@ -6,6 +6,7 @@
 
 .class { /* Correct usage of zero values */
 	font-family: Georgia, serif;
+	font-weight: bolder; /* Ignore relative font weights */
 	text-shadow:
 		0 -1px 0 rgba(0, 0, 0, 0.5),
 		0 1px 0 #fff;

--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ module.exports = {
     "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",
     "font-family-name-quotes": "always-where-recommended",
-    "font-weight-notation": "numeric",
+    "font-weight-notation": [ "numeric", {
+      ignore: ["relative"],
+    } ],
     "function-calc-no-unspaced-operator": true,
     "function-comma-space-after": "always",
     "function-comma-space-before": "never",


### PR DESCRIPTION
Fixes #98 