### PR TITLE
fix: Remove stylelint v8 deprecated rule `rule-non-nested-empty-line-before` from SCSS config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+-   Removed: `rule-non-nested-empty-line-before` rule from SCSS config. This rule is deprecated in stylelint v8, the new `rule-empty-line-before` rule already exists in the primary config.
+
 # 10.0.0
 
 -   Added: `scss/selector-no-redundant-nesting-selector` rule in `stylelint-config-wordpress/scss` chared config.

--- a/scss.js
+++ b/scss.js
@@ -27,7 +27,6 @@ module.exports = {
       },
     ],
     "at-rule-name-space-after": "always",
-    "rule-non-nested-empty-line-before": "always",
     "scss/at-else-closing-brace-newline-after": "always-last-in-chain",
     "scss/at-else-closing-brace-space-after": "always-intermediate",
     "scss/at-else-empty-line-before": "never",


### PR DESCRIPTION
Removed: `rule-non-nested-empty-line-before` rule from SCSS config. 

This rule is deprecated in stylelint v8, the new `rule-empty-line-before` rule already exists in the primary config and as the SCSS config extends the primary config this is not required.